### PR TITLE
Angle format fixes

### DIFF
--- a/trunk/src/main/java/org/osgeo/proj4j/units/Angle.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/units/Angle.java
@@ -32,7 +32,13 @@ public class Angle
     boolean negate = false;
     int length = text.length();
     if (length > 0) {
-      char c = Character.toUpperCase(text.charAt(length-1));
+
+    	// By previously forcing an upper case conversion here,
+    	// angles formatted in AngleFormat.ddmmssPattern4 are
+    	// parsed incorrectly (that pattern appends the second
+    	// abbreviation s to the end of the angle string.)
+    	char c = text.charAt(length-1);
+
       switch (c) {
       case AngleFormat.CH_W:
       case AngleFormat.CH_S:
@@ -51,6 +57,20 @@ public class Angle
       String dd = text.substring(0, i);
       String mmss = text.substring(i+1);
       d = Double.valueOf(dd).doubleValue();
+
+      // This line is needed to properly parse negative angles with
+      // magnitudes less than 1 degree in following angle formats:
+      //
+      // AngleFormat.ddmmssPattern
+      // Previous failure case: -0d59     -->  0.983333 decimal degrees
+      //
+      // AngleFormat.ddmmssPattern2
+      // Previous failure case: -0d59'59" -->  0.999722 decimal degrees
+      //
+      // AngleFormat.ddmmssPattern4
+      // Previous failure case: -0d59m59s -->  0.999722 decimal degrees
+      if(dd.startsWith("-") && d == 0.0) negate = true;
+
       i = mmss.indexOf(AngleFormat.CH_MIN_ABBREV);
       if (i == -1)
         i = mmss.indexOf(AngleFormat.CH_MIN_SYMBOL);

--- a/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
@@ -73,7 +73,6 @@ public class AngleFormat extends NumberFormat {
 
 	public StringBuffer format(double number, StringBuffer result, FieldPosition fieldPosition) {
 		int length = pattern.length();
-		int f;
 		boolean negative = false;
 
 		if (number < 0) {
@@ -87,11 +86,48 @@ public class AngleFormat extends NumberFormat {
 			}
 		}
 		
-		double ddmmss = isDegrees ? number : Math.toDegrees(number);
-		int iddmmss = (int)Math.round(ddmmss * 3600);
-		if (iddmmss < 0)
-			iddmmss = -iddmmss;
-		int fraction = iddmmss % 3600;
+		int sign = 1;
+		if(number < 0.0)
+		{
+			sign = -1;
+			number = -number;
+		}
+
+		// The previous method of converting an angle from decimal degrees
+		// to integer degrees, minutes, and seconds relied on a mixture of
+		// casting doubles as integers and using Math.round() in way that was
+		// numerically unstable. Examples of failure cases for all defined
+		// formats are given below.
+		//
+		// AngleFormat.ddmmssPattern
+		// Previous failure case: 29.99999999 --> 29d00
+		//
+		// AngleFormat.ddmmssPattern2
+		// Previous failure case: 29.99999999 --> 29d00'59"
+		//
+		// AngleFormat.ddmmssLongPattern
+		// Previous failure case: 29.99999999 --> 29d00'59"E
+		//
+		// AngleFormat.ddmmssLatPattern
+		// Previous failure case: 29.99999999 --> 29d00'59"N
+		//
+		// AngleFormat.ddmmssPattern4
+		// Previous failure case: 29.99999999 --> 29d00m59s
+		//
+		// AngleFormat.Test case: decimalPattern
+		// Previous failure case: 29.99999999 --> 29.1000000
+
+		double          degrees = isDegrees ? number : Math.toDegrees(number);
+		int     integer_degrees = (int)Math.floor(degrees);
+		double  decimal_degrees = degrees - integer_degrees;
+
+		double          minutes = decimal_degrees * 60.0;
+		int     integer_minutes = (int)Math.floor(minutes);
+		double  decimal_minutes = minutes - integer_minutes;
+
+		double          seconds = decimal_minutes * 60.0;
+		int     integer_seconds = (int)Math.floor(seconds);
+//		double  decimal_seconds = seconds - integer_seconds;
 
 		for (int i = 0; i < length; i++) {
 			char c = pattern.charAt(i);
@@ -100,22 +136,32 @@ public class AngleFormat extends NumberFormat {
 				result.append(number);
 				break;
 			case 'D':
-				result.append((int)ddmmss);
+				// This handles the case where the integer degrees equal zero,
+				// but the angle is negative
+				//
+				// AngleFormat.ddmmssPattern
+				// Previous failure case: -0.999722 --> 0d59
+				//
+				// AngleFormat.ddmmssPattern2
+				// Previous failure case: -0.999722 --> 0d59'59"
+				//
+				// AngleFormat.ddmmssPattern4
+				// Previous failure case: -0.999722 --> 0d59m59s
+				result.append(String.format("%s%d", ( sign == -1 ? "-" : "" ), integer_degrees));
 				break;
 			case 'M':
-				f = fraction / 60;
-				if (f < 10)
-					result.append('0');
-				result.append(f);
+				// Ensures two digits are used and avoids rounding errors
+				result.append(String.format("%02d", integer_minutes));
 				break;
 			case 'S':
-				f = fraction % 60;
-				if (f < 10)
-					result.append('0');
-				result.append(f);
+				// Ensures two digits are used and avoids rounding errors
+				result.append(String.format("%02d", integer_seconds));
 				break;
 			case 'F':
-				result.append(fraction);
+				// Ensures six digits are used and that leading zeros will be
+				// appended if there are fewer than six digits. The choice of
+				// six decimal places is completely arbitrary.
+				result.append(String.format("%06d", (int)(decimal_degrees * 1000000.0)));
 				break;
 			case 'W':
 				if (negative)

--- a/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
@@ -118,6 +118,14 @@ public class AngleFormat extends NumberFormat {
 		// Previous failure case: 29.99999999 --> 29.1000000
 
 		double          degrees = isDegrees ? number : Math.toDegrees(number);
+
+		// This is necessary for cases like this: 128.99999999999997
+		// The problem occurs when the decimal degrees are within 1e-12 or less
+		// of an integer value because case 'F' below will automatically round
+		// the decimal degrees to 1.0
+		if(Math.abs(Math.round(degrees) - degrees) <= 1e-12)
+			degrees = Math.round(degrees);
+
 		int     integer_degrees = (int)Math.floor(degrees);
 		double  decimal_degrees = degrees - integer_degrees;
 
@@ -162,7 +170,7 @@ public class AngleFormat extends NumberFormat {
 				// places, will be output if non-zero
 				String string = String.format("%.12f", decimal_degrees);
 				int end = string.length();
-				for(int j=string.length()-1;j>=2;j--) {
+				for(int j=string.length()-1;j>=3;j--) {
 					if(string.charAt(j) == '0')
 						end--;
 					else

--- a/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/units/AngleFormat.java
@@ -158,10 +158,17 @@ public class AngleFormat extends NumberFormat {
 				result.append(String.format("%02d", integer_seconds));
 				break;
 			case 'F':
-				// Ensures six digits are used and that leading zeros will be
-				// appended if there are fewer than six digits. The choice of
-				// six decimal places is completely arbitrary.
-				result.append(String.format("%06d", (int)(decimal_degrees * 1000000.0)));
+				// Ensures all available decimal digits, up to 12 decimal
+				// places, will be output if non-zero
+				String string = String.format("%.12f", decimal_degrees);
+				int end = string.length();
+				for(int j=string.length()-1;j>=2;j--) {
+					if(string.charAt(j) == '0')
+						end--;
+					else
+						break;
+				}
+				result.append(string.substring(2,end));
 				break;
 			case 'W':
 				if (negative)

--- a/trunk/src/test/java/org/osgeo/proj4j/AngleFormatTestCase.java
+++ b/trunk/src/test/java/org/osgeo/proj4j/AngleFormatTestCase.java
@@ -1,0 +1,221 @@
+package org.osgeo.proj4j;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestListener;
+import junit.framework.TestResult;
+
+import org.osgeo.proj4j.units.Angle;
+import org.osgeo.proj4j.units.AngleFormat;
+
+/**
+ * Unit test class for angle format generation and parsing in PROJ4J.
+ * Each angle format defined in the AngleFormat class is tested through
+ * a full range of angles by first performing a forward format conversion
+ * from decimal degrees to the specified format and then performing the
+ * inverse conversion. The end result is compared to the starting value
+ * subject to an error threshold that depends upon the particular format.
+ * In most cases the error threshold is 1 arcsecond, but in the case of the 
+ * ddmmssPattern, which does not display seconds, an error of up to 59 
+ * arcseconds could result from the forward and inverse conversion calculations,
+ * so its error threshold must take this into account. To further mitigate decimal 
+ * inaccuracies in the calculations, a safety margin of 2 has been factored into
+ * the error thresholds.
+ * 
+ * @author jgyorfi
+ */
+public class AngleFormatTestCase extends TestCase implements TestListener
+{
+	public AngleFormatTestCase(String name)
+	{
+		super(name);
+	}
+	
+	/**
+	 * Despite this pattern's name, it doesn't actually include
+	 * seconds. The maximum error is therefore 59 seconds of arc.
+	 * The factor of 2 on the error 
+	 * 
+	 * Example: -123.456 degrees is formatted -123d27
+	 */
+	public void ddmmssPattern()
+	{
+		performTest(AngleFormat.ddmmssPattern, 2.0 * 59.0 / 3600.0);
+	}
+	
+	/**
+	 * This pattern extends the one above by including seconds using
+	 * the minutes symbol ' and the seconds symbol ".
+	 * 
+	 * Example: -123.456 degrees is formatted -123d27'21"
+	 */
+	public void ddmmssPattern2()
+	{
+		performTest(AngleFormat.ddmmssPattern2, 2.0 / 3600.0);
+	}
+
+	/**
+	 * This pattern is a variation on the ddmmssPattern2 that formats
+	 * longitudes with the east suffix (E) if positive and the west
+	 * suffix (W) if negative.
+	 * 
+	 * Example: -123.456 degrees is formatted 123d27'21"W
+	 */
+	public void ddmmssLongPattern()
+	{
+		performTest(AngleFormat.ddmmssLongPattern, 2.0 / 3600.0);
+	}
+	
+	/**
+	 * This pattern is a variation on the ddmmssPattern2 that formats
+	 * latitudes with the north suffix (N) if positive and the south
+	 * suffix (S) if negative.
+	 * 
+	 * Example: -123.456 degrees is formatted 123d27'21"S
+	 *          (Yes, I know latitudes don't go that low, but
+	 *           this is a good stress test for the formatter)
+	 */
+	public void ddmmssLatPattern()
+	{
+		performTest(AngleFormat.ddmmssLatPattern, 2.0 / 3600.0);
+	}
+
+	/**
+	 * This pattern is the same as ddmmssPattern2 except that
+	 * it uses the minutes abbreviation m and the seconds
+	 * abbreviation s.
+	 * 
+	 * Example: -123.456 degrees is formatted -123d27m21s 
+	 */
+	public void ddmmssPattern4()
+	{
+		performTest(AngleFormat.ddmmssPattern4, 2.0 / 3600.0);
+	}
+	
+	/**
+	 * This pattern displays angles in decimal degrees. The choice
+	 * of 6 decimal places is arbitrary and can be changed in the
+	 * AngleFormat class. The maximum error at this resolution is
+	 * 0.0036 seconds of arc.
+	 * 
+	 * Example: -123.456 degrees is formatted -123.456000 
+	 */
+	public void decimalPattern()
+	{
+		performTest(AngleFormat.decimalPattern, 1.0 / 3600.0);
+	}
+
+	/**
+	 * Each of the test cases above calls this method to perform
+	 * forward and inverse angle format conversions, comparing the
+	 * initial angle value to the final result. The test angles are
+	 * incremented from -180 degrees to +180 degrees in 1 arcsecond
+	 * increments. The error threshold depends upon the test. In most
+	 * cases, a threshold of 2 arcseconds is used whereas for the
+	 * ddmmssPattern, which ignores seconds, a threshold of 2 minutes
+	 * is used.
+	 * 
+	 * @param angleFormatPattern
+	 * @param eps
+	 */
+	private void performTest(String angleFormatPattern, double eps)
+	{
+		final StringBuffer sb = new StringBuffer();
+		final AngleFormat af = new AngleFormat(angleFormatPattern, true);
+		
+		for(int deg=-180; deg<=180; deg++) 
+		{
+			for(int min=0; min<=59; min++)
+			{
+				for(int sec=0; sec<=59; sec++)
+				{
+					double theta1 = 
+						(double)deg + 
+						(double)min / 60.0 + 
+						(double)sec / 3600.0;
+
+					// Forward conversion (decimal degrees to specified format)
+					sb.delete(0,sb.length());
+					af.format(theta1, sb, null); 
+					
+					// Inverse conversion (specified format to decimal degrees)
+					double theta2 = Angle.parse(sb.toString());
+
+					// Output error case, if any
+					String string = String.format("%12.6f --> %s --> %12.6f", theta1, sb.toString(), theta2);
+					assertTrue(string, Math.abs(theta2 - theta1) <= eps);
+				}
+			}
+		}
+	}
+	
+	private boolean failed = false;
+	
+	@Override
+	public void addError(Test test, Throwable throwable)
+	{
+	}
+
+	@Override
+	public void addFailure(Test test, AssertionFailedError error)
+	{
+		failed = true;
+		System.out.println("Failure: " + error.getMessage());
+	}
+
+	@Override
+	public void endTest(Test arg0)
+	{
+		if(!failed)
+			System.out.println("Success");
+		System.out.println();
+	}
+
+	@Override
+	public void startTest(Test test)
+	{
+		System.out.println("Test case: " + ((AngleFormatTestCase)test).getName());
+	}
+
+	/**
+	 * Each angle format is run as a separate test case.
+	 * 
+	 * @param args
+	 */
+	public static void main(String[] args)
+	{
+		AngleFormatTestCase testCase;
+		TestResult testResult;
+		
+		testCase = new AngleFormatTestCase("ddmmssPattern");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+
+		testCase = new AngleFormatTestCase("ddmmssPattern2");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+
+		testCase = new AngleFormatTestCase("ddmmssLongPattern");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+
+		testCase = new AngleFormatTestCase("ddmmssLatPattern");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+		
+		testCase = new AngleFormatTestCase("ddmmssPattern4");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+
+		testCase = new AngleFormatTestCase("decimalPattern");
+		testResult = new TestResult();
+		testResult.addListener(testCase);
+		testCase.run(testResult);
+	}
+}


### PR DESCRIPTION
There were many problems converting and parsing angle formats. The modified Angle and AngleFormat classes contain detailed descriptions of the errors and their fixes. A unit test class AngleFormatTestCase was added that sweeps from -180 degrees to +180 degrees in 1 arcsecond increments and tests forward conversion (decimal degrees to specified format) and inverse conversion (specified format to decimal degrees) comparing the initial angle to the final result subject to an error threshold.