### PR TITLE
Stereographic azimuthal projection bug fix

### DIFF
--- a/trunk/src/main/java/org/osgeo/proj4j/proj/Projection.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/proj/Projection.java
@@ -75,20 +75,20 @@ public abstract class Projection implements Cloneable {
 	 */
 	protected double projectionLatitude2 = 0.0;
 
-  /**
-   * The projection alpha value
-   */
-  protected double alpha = Double.NaN;
+    /**
+     * The projection alpha value
+     */
+    protected double alpha = Double.NaN;
 
-  /**
-   * The projection lonc value
-   */
-  protected double lonc = Double.NaN;
+    /**
+     * The projection lonc value
+     */
+    protected double lonc = Double.NaN;
 
-  /**
-   * The projection scale factor
-   */
-  protected double scaleFactor = 1.0;
+    /**
+     * The projection scale factor
+     */
+    protected double scaleFactor = 1.0;
 
 	/**
 	 * The false Easting of this projection
@@ -100,10 +100,11 @@ public abstract class Projection implements Cloneable {
 	 */
 	protected double falseNorthing = 0;
 
-  /**
-   * Indicates whether a Southern Hemisphere UTM zone
-   */
-  protected boolean isSouth = false;
+    /**
+     * Indicates whether a Southern Hemisphere UTM zone
+     */
+    protected boolean isSouth = false;
+  
 	/**
 	 * The latitude of true scale. Only used by specific projections.
 	 */
@@ -169,15 +170,21 @@ public abstract class Projection implements Cloneable {
 	 */
 	private double totalFalseEasting = 0;
 
-  /**
-   * falseNorthing, adjusted to the appropriate units using fromMetres
-   */
-  private double totalFalseNorthing = 0;
+    /**
+     * falseNorthing, adjusted to the appropriate units using fromMetres
+     */
+    private double totalFalseNorthing = 0;
 
-  /**
-   * units of this projection.  Default is metres, but may be degrees
-   */
-  protected Unit unit = null;
+    /**
+     * units of this projection.  Default is metres, but may be degrees
+     */
+    protected Unit unit = null;
+
+    /**
+     * Flag indicating whether or not the true scale latitude
+     * was set via PROJ4 param
+     */
+    protected boolean isTrueScaleLatitudeSet = false;
 
 	// Some useful constants
 	protected final static double EPS10 = 1e-10;
@@ -547,6 +554,7 @@ public abstract class Projection implements Cloneable {
 	 */
 	public void setTrueScaleLatitude( double trueScaleLatitude ) {
 		this.trueScaleLatitude = trueScaleLatitude;
+		isTrueScaleLatitudeSet = true;
 	}
 	
 	public double getTrueScaleLatitude() {
@@ -558,6 +566,7 @@ public abstract class Projection implements Cloneable {
 	 */
 	public void setTrueScaleLatitudeDegrees( double trueScaleLatitude ) {
 		this.trueScaleLatitude = DTR*trueScaleLatitude;
+		isTrueScaleLatitudeSet = true;
 	}
 	
 	public double getTrueScaleLatitudeDegrees() {

--- a/trunk/src/main/java/org/osgeo/proj4j/proj/StereographicAzimuthalProjection.java
+++ b/trunk/src/main/java/org/osgeo/proj4j/proj/StereographicAzimuthalProjection.java
@@ -35,7 +35,7 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 
 	public StereographicAzimuthalProjection(double projectionLatitude, double projectionLongitude) {
 		super(projectionLatitude, projectionLongitude);
-		initialize();
+		//initialize();
 	}
 	
 	public void setupUPS(int pole) {
@@ -45,7 +45,7 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 		falseEasting = 2000000.0;
 		falseNorthing = 2000000.0;
 		trueScaleLatitude = ProjectionMath.HALFPI;
-		initialize();
+		//initialize();
 	}
 	
 	public void initialize() {
@@ -53,7 +53,18 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 
 		super.initialize();
 		if (Math.abs((t = Math.abs(projectionLatitude)) - ProjectionMath.HALFPI) < EPS10)
+		{
 			mode = projectionLatitude < 0. ? SOUTH_POLE : NORTH_POLE;
+
+			// If the projection latitude is at either pole and the true scale latitude
+			// was not explicitly set via PROJ4 param... 
+			if(!isTrueScaleLatitudeSet)
+			{
+				// ...set the true scale latitude to the appropriate pole
+				setTrueScaleLatitude((projectionLatitude < 0.0 ? -ProjectionMath.HALFPI : ProjectionMath.HALFPI));
+			}
+			// ...otherwise, use whatever true scale latitude was set
+		}
 		else
 			mode = t > EPS10 ? OBLIQUE : EQUATOR;
 		trueScaleLatitude = Math.abs(trueScaleLatitude);


### PR DESCRIPTION
When the projection latitude is either +/-90 degrees, the PROJ4J stereographic azimuthal projection value diverges
from the PROJ4 command line value. The root cause of this divergence is that the true scale latitude was not being
properly updated. To match the command line output, the true scale latitude must be set to the projection latitude
unless a specific true scale latitude is specified via the lat_ts parameter in the PROJ4 string.